### PR TITLE
Adds a block-capable stringForObject:

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -55,8 +55,7 @@ blaze a trail with your iOS apps. Nimbus will soon be using SOCKit in a re-envis
 navigator.
 
 Users of RESTKit will notice that SOCKit provides similar functionality to RESTKit's
-[RKMakePathWithObject][]. It's easy to imagine a point in the near future where
-`RKMakePathWithObject` uses SOCKit behind the scenes.
+[RKMakePathWithObject][]. In fact, both `RKMakePathWithObject` and the underlying `RKPathMatcher` class rely on SOCKit behind the scenes.
 
 ## Add SOCKit to your project
 

--- a/SOCKit.h
+++ b/SOCKit.h
@@ -133,8 +133,35 @@
  *
  * Collection Operators:
  * http://developer.apple.com/library/ios/#documentation/cocoa/conceptual/KeyValueCoding/Articles/CollectionOperators.html#//apple_ref/doc/uid/20002176-BAJEAIEE
+ *  @see stringFromObject:withBlock:
  */
 - (NSString *)stringFromObject:(id)object;
+
+#if NS_BLOCKS_AVAILABLE
+/**
+ * Returns a string with the parameters of this pattern replaced using Key-Value Coding (KVC)
+ * on the receiving object, and the result is (optionally) modified or encoded by the block. 
+ * 
+ * For example, consider we have individual object values that need percent escapes added to them,
+ * while preserving the the slashes, question marks, and ampersands of a typical resource path. 
+ * Using blocks, this is very succinct:
+ * 
+ * NSDictionary *person = [NSDictionary dictionaryWithObjectsAndKeys:@"SECRET|KEY",@"password", 
+ *     @"Joe Bob Briggs", @"name", nil];
+ * SOCPattern *soc = [SOCPattern patternWithString:@"/people/:name/:password"];
+ * NSString *actualPath = [soc stringFromObject:person withBlock:^(NSString *)interpolatedString) {
+ *     return [interpolatedString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+ * }
+ * NSString *expectedPath = @"/people/Joe%20Bob%20Briggs/SECRET%7CKEY";
+ *
+ *      @param object  The object whose properties you want to interpolate
+ *      @param block   An optional block (may be nil) that modifies or encodes the interpolated 
+ *                     property value string.  If block is not nil, it must at least the incoming string.
+ *      @returns A string with the interpolated values from the object, using the pre-configured pattern.
+ *      @see stringFromObject:
+ */
+- (NSString *)stringFromObject:(id)object withBlock:(NSString*(^)(NSString*))block;
+#endif
 
 @end
 


### PR DESCRIPTION
Adds a block-capable stringForObject: that allows third-party developers
to transform an object's interpolated property values before injection
into the pattern.  This opens the door for adding percent escapes to
object value strings, without altering the overall validity of a url's
resource path.  Added documentation and test cases to showcase the new
functionality.  Additional cleansing is possible, with the assumption
that blocks are always available (iOS 4, newer OS X's), however in it's
current implementation it will function exactly as it did before
regardless.  Refs #4
