### PR TITLE
Add support for escaped KVC characters.

### DIFF
--- a/SOCKit.h
+++ b/SOCKit.h
@@ -55,19 +55,37 @@
  *   returns: nil because setUsername: does not have a return value. githubUser's username property
  *            is now @"jverkoey".
  *
- * Note:
+ * Note: Parameters must be separated by string literals
  *
  *      Pattern parameters must be separated by some sort of non-parameter character.
  *      This means that you can't define a pattern like :user:repo. This is because when we
  *      get around to wanting to decode the string back into an object we need some sort of
  *      delimiter between the parameters.
  *
- * Note 2:
+ * Note 2: When colons aren't parameters
  *
  *      If you have colons in your text that aren't followed by a valid parameter name then the
  *      colon will be treated as static text. This is handy if you're defining a URL pattern.
  *      For example: @"http://github.com/:user" only has one parameter, :user. The ":" in http://
  *      is ignored.
+ *
+ * Note 3: Escaping KVC characters
+ *
+ *      If you need to use a KVC character in a SOCKit pattern as a literal string token and not
+ *      a KVC character then you can escape the character using a double backslash. For example,
+ *      @"/:userid.json" would create a pattern that uses KVC to access the json property of the
+ *      username value. In this case we wish to interpret the ".json" portion as a static string.
+ *      In order to do so we can escape the "." using a double backslash, "\\". For example:
+ *      @"/:userid\\.json". This will allow strings of the form @"/3.json" to be matched by the
+ *      pattern. This also works with outbound parameters, so that the string @"/3.json" can
+ *      be used with the pattern to invoke a selector with "3" as the first argument rather
+ *      than "3.json".
+ *
+ *      You can escape the following characters:
+ *      ":" => @"\\:"
+ *      "@" => @"\\@"
+ *      "." => @"\\."
+ *      "\\" => @"\\\\"
  */
 @interface SOCPattern : NSObject {
 @private

--- a/SOCKit.m
+++ b/SOCKit.m
@@ -30,6 +30,7 @@ typedef enum {
 } SOCArgumentType;
 
 SOCArgumentType SOCArgumentTypeForTypeAsChar(char argType);
+NSString* kTemporaryBackslashToken = @"/backslash/";
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -115,9 +116,17 @@ SOCArgumentType SOCArgumentTypeForTypeAsChar(char argType);
 
   NSCharacterSet* nonParameterCharacterSet = [self nonParameterCharacterSet];
 
+  // Turn escaped backslashes into a special backslash token to avoid \\. being interpreted as
+  // `\` and `\.` rather than `\\` and `.`.
+  NSString* escapedPatternString = _patternString;
+  if ([escapedPatternString rangeOfString:@"\\\\"].length > 0) {
+    escapedPatternString = [escapedPatternString stringByReplacingOccurrencesOfString: @"\\\\"
+                                                                           withString: kTemporaryBackslashToken];
+  }
+  
   // Scan through the string, creating tokens that are either strings or parameters.
   // Parameters are prefixed with ":".
-  NSScanner* scanner = [NSScanner scannerWithString:_patternString];
+  NSScanner* scanner = [NSScanner scannerWithString:escapedPatternString];
 
   // NSScanner skips whitespace and newlines by default (not ideal!).
   [scanner setCharactersToBeSkipped:nil];
@@ -127,8 +136,18 @@ SOCArgumentType SOCArgumentTypeForTypeAsChar(char argType);
     [scanner scanUpToString:@":" intoString:&token];
 
     if ([token length] > 0) {
-      // Add this static text to the token list.
-      [tokens addObject:token];
+      if (![token hasSuffix:@"\\"]) {
+        // Add this static text to the token list.
+        [tokens addObject:token];
+
+      } else {
+        // This token is escaping the next colon, so we skip the parameter creation.
+        [tokens addObject:[token stringByAppendingString:@":"]];
+
+        // Skip the colon.
+        [scanner setScanLocation:[scanner scanLocation] + 1];
+        continue;
+      }
     }
 
     if (![scanner isAtEnd]) {
@@ -179,6 +198,26 @@ SOCArgumentType SOCArgumentTypeForTypeAsChar(char argType);
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (NSString *)_stringFromEscapedToken:(NSString *)token {
+  if ([token rangeOfString:@"\\"].length == 0
+      && [token rangeOfString:kTemporaryBackslashToken].length == 0) {
+    // The common case (faster and creates fewer autoreleased strings).
+    return token;
+    
+  } else {
+    // Escaped characters may exist.
+    // Create a mutable copy so that we don't excessively create new autoreleased strings.
+    NSMutableString* mutableToken = [token mutableCopy];
+    [mutableToken replaceOccurrencesOfString:@"\\." withString:@"." options:0 range:NSMakeRange(0, [mutableToken length])];
+    [mutableToken replaceOccurrencesOfString:@"\\@" withString:@"@" options:0 range:NSMakeRange(0, [mutableToken length])];
+    [mutableToken replaceOccurrencesOfString:@"\\:" withString:@":" options:0 range:NSMakeRange(0, [mutableToken length])];
+    [mutableToken replaceOccurrencesOfString:kTemporaryBackslashToken withString:@"\\" options:0 range:NSMakeRange(0, [mutableToken length])];
+    return [mutableToken autorelease];
+  }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - Public Methods
 
@@ -198,6 +237,9 @@ SOCArgumentType SOCArgumentTypeForTypeAsChar(char argType);
   for (id token in _tokens) {
 
     if ([token isKindOfClass:[NSString class]]) {
+      // Replace the escaped characters in the token before we start comparing the string.
+      token = [self _stringFromEscapedToken:token];
+
       NSInteger tokenLength = [token length];
       if (validUpUntil + tokenLength > stringLength) {
         // There aren't enough characters in the string to satisfy this token.
@@ -218,7 +260,7 @@ SOCArgumentType SOCArgumentTypeForTypeAsChar(char argType);
 
       // Look ahead for the next string token match.
       if (tokenIndex + 1 < [_tokens count]) {
-        NSString* nextToken = [_tokens objectAtIndex:tokenIndex + 1];
+        NSString* nextToken = [self _stringFromEscapedToken:[_tokens objectAtIndex:tokenIndex + 1]];
         NSAssert([nextToken isKindOfClass:[NSString class]], @"The token following a parameter must be a string.");
 
         NSRange nextTokenRange = [string rangeOfString:nextToken options:0 range:NSMakeRange(validUpUntil, stringLength - validUpUntil)];
@@ -379,7 +421,7 @@ SOCArgumentType SOCArgumentTypeForTypeAsChar(char argType);
 
   for (id token in _tokens) {
     if ([token isKindOfClass:[NSString class]]) {
-      [accumulator appendString:token];
+      [accumulator appendString:[self _stringFromEscapedToken:token]];
 
     } else {
       SOCParameter* parameter = token;

--- a/tests/SOCKitTests.m
+++ b/tests/SOCKitTests.m
@@ -117,6 +117,36 @@ NSString *sockitBetterURLEncodeString(NSString *unencodedString);
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+- (void)testCharacterEscapes {
+  NSDictionary* obj = [NSDictionary dictionaryWithObjectsAndKeys:
+                       [NSNumber numberWithInt:1337], @"leet",
+                       [NSNumber numberWithInt:5000], @"five",
+                       nil];
+
+  STAssertTrue([SOCStringFromStringWithObject(@".", obj) isEqualToString:@"."], @"Should be the same string.");
+  STAssertTrue([SOCStringFromStringWithObject(@"\\.", obj) isEqualToString:@"."], @"Should be the same string.");
+  STAssertTrue([SOCStringFromStringWithObject(@":", obj) isEqualToString:@":"], @"Should be the same string.");
+  STAssertTrue([SOCStringFromStringWithObject(@"\\:", obj) isEqualToString:@":"], @"Should be the same string.");
+  STAssertTrue([SOCStringFromStringWithObject(@"@", obj) isEqualToString:@"@"], @"Should be the same string.");
+  STAssertTrue([SOCStringFromStringWithObject(@"\\@", obj) isEqualToString:@"@"], @"Should be the same string.");
+
+  STAssertTrue([SOCStringFromStringWithObject(@":leet\\.value", obj) isEqualToString:@"1337.value"], @"Should be the same string.");
+  STAssertTrue([SOCStringFromStringWithObject(@":leet\\:value", obj) isEqualToString:@"1337:value"], @"Should be the same string.");
+  STAssertTrue([SOCStringFromStringWithObject(@":leet\\@value", obj) isEqualToString:@"1337@value"], @"Should be the same string.");
+  STAssertTrue([SOCStringFromStringWithObject(@":leet\\:\\:value", obj) isEqualToString:@"1337::value"], @"Should be the same string.");
+  STAssertTrue([SOCStringFromStringWithObject(@":leet\\:\\:\\.\\@value", obj) isEqualToString:@"1337::.@value"], @"Should be the same string.");
+  STAssertTrue([SOCStringFromStringWithObject(@"\\\\:leet", obj) isEqualToString:@"\\1337"], @"Should be the same string.");
+
+  SOCPattern* pattern = [SOCPattern patternWithString:@"soc://\\:ident"];
+  STAssertTrue([pattern stringMatches:@"soc://:ident"], @"String should conform.");
+  pattern = [SOCPattern patternWithString:@"soc://\\\\:ident"];
+  STAssertTrue([pattern stringMatches:@"soc://\\3"], @"String should conform.");
+  pattern = [SOCPattern patternWithString:@"soc://:ident\\.json"];
+  STAssertTrue([pattern stringMatches:@"soc://3.json"], @"String should conform.");
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 - (void)testCollectionOperators {
   NSDictionary* obj = [NSDictionary dictionaryWithObjectsAndKeys:
                        [NSNumber numberWithInt:1337], @"leet",


### PR DESCRIPTION
This implementation is really rough. There is likely room to iterate.

What this solution does is provides support for escaping the following
characters in patterns:
- .
- @
- :
- \

These characters may be escaped using a double backslash. We use a double
backslash rather than a single backslash because a single backslash acts
as an Objective-C string literal character escape which is not what we
want here (and will raise compiler warnings due to unrecognized escape
characters). The double backslash allows us to programmatically replace
the above characters while matching the pattern.

An example pattern that requires escaping:

```
/:userid.json
```

Without character escaping, this pattern would be interpreted as fetching
the userid property and then fetching the json property of that userid. This would
throw a KVC exception. When going outbound, a string of the form "/3.json" would end
up passing "3.json" as the parameter, rather than the desired "3".

The escaped version of this string would look like this:

```
/:userid\\.json
```

This allows us to create a string from an object's userid property of the form
"/3.json". It also allows us to extract the correct value from a string of the
form "/3.json", providing the value "3" to the first parameter of the selector.
