### PR TITLE
Add a CocoaPods podspec.

### DIFF
--- a/SOCKit.podspec
+++ b/SOCKit.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name      = "SOCKit"
+  s.version   = "1.0"
+  s.summary   = "String <-> Object Coder for Objective-C."
+  s.homepage  = "http://github.com/jverkoey/SOCKit"
+  s.author    = { "Jeff Verkoeyen" => "jverkoey@gmail.com" }
+  s.source    = { :git => "https://github.com/jverkoey/sockit.git", :tag => "1.0" }
+
+  # TODO uncomment when CocoaPods 0.6 is released
+  # s.license  = { :type => 'Apache License Version 2.0', :file => 'LICENSE' }
+
+  s.description = 'With SOCKit and SOCPattern you can easily transform objects into strings and vice versa.'
+
+  s.source_files = '*.{h,m}'
+  s.clean_paths  = "tests", "SOCKit.xcodeproj"
+end


### PR DESCRIPTION
This way people can easily install the cutting-edge version of the lib directly from the repo and makes it easier to keep the spec up-to-date.
