### PR TITLE
Fix crash in -performSelector:onObject:sourceString: when object is nil

### DIFF
--- a/SOCKit.m
+++ b/SOCKit.m
@@ -394,6 +394,9 @@ NSString* kTemporaryBackslashToken = @"/backslash/";
   if (isInitializer) {
     object = [[object alloc] autorelease];
   }
+  
+  if (!object)
+    return nil;
 
   NSArray* values = nil;
   BOOL succeeded = [self gatherParameterValues:&values fromString:sourceString];


### PR DESCRIPTION
In my project SOCKit was crashing, when I was returning nil from alloc/init methods (sometimes it's needed to avoid any transitions in our routing system).

Thanks!
