### PR TITLE
fix crash in ARC by using __autoreleasing

### DIFF
--- a/src/SOCKit.m
+++ b/src/SOCKit.m
@@ -331,8 +331,12 @@ NSString* kTemporaryBackslashToken = @"/backslash/";
   BOOL succeeded = [self gatherParameterValues:&values fromString:sourceString];
   NSAssert(succeeded, @"The pattern can't be used with this string.");
   
-  id returnValue = nil;
-
+#if __has_feature(objc_arc)
+    id __autoreleasing returnValue = nil;
+#else
+    id returnValue = nil;
+#endif
+  
   if (succeeded) {
     NSMethodSignature* sig = [object methodSignatureForSelector:selector];
     NSAssert(nil != sig, @"%@ does not respond to selector: '%@'", object, NSStringFromSelector(selector));


### PR DESCRIPTION
in Xcode 6.1 default ARC, the "returnValue" would be release when returned, so EXC_BAD_ACCESS crash, use __autoreleasing could be work