### PR TITLE
Cache nonParameterCharacterSet to help minimize memory footprint in multithreaded apps using SOCKit.

### DIFF
--- a/src/SOCKit.m
+++ b/src/SOCKit.m
@@ -71,10 +71,13 @@ NSString* kTemporaryBackslashToken = @"/backslash/";
 #pragma mark - Pattern Compilation
 
 - (NSCharacterSet *)nonParameterCharacterSet {
-  NSMutableCharacterSet* parameterCharacterSet = [NSMutableCharacterSet alphanumericCharacterSet];
-  [parameterCharacterSet addCharactersInString:@".@_"];
-  NSCharacterSet* nonParameterCharacterSet = [parameterCharacterSet invertedSet];
-  return nonParameterCharacterSet;
+  static NSCharacterSet* staticNonParameterCharacterSet = nil;
+  if (staticNonParameterCharacterSet == nil) {
+    NSMutableCharacterSet* parameterCharacterSet = [NSMutableCharacterSet alphanumericCharacterSet];
+    [parameterCharacterSet addCharactersInString:@".@_"];
+    staticNonParameterCharacterSet = [parameterCharacterSet invertedSet];
+  }
+  return staticNonParameterCharacterSet;
 }
 
 - (void)_compilePattern {


### PR DESCRIPTION
iOS today extensions are limited to use 10-11MB of the heap.

One of the today extensions I'm working with has Reskit + SOCKit stack and is issuing a bunch of networking requests in parallel. As you can see from attached image of Allocations utility, one call to nonParameterCharacterSet takes up north of 32KB. (all of these allocations are related to single call).

Caching this value can pose significant memory savings for apps that are hitting on SOCKit frequently in concurrent fashion.

<img width="1424" alt="screen shot 2015-07-05 at 10 14 50 pm" src="https://cloud.githubusercontent.com/assets/1530544/8516055/a1917e36-2363-11e5-85e8-3ff6d917f0fe.png">